### PR TITLE
Fix compile and one test

### DIFF
--- a/bmm/src/test/java/org/openehr/bmm/persistence/deserializer/BmmSchemaDeserializerTest.java
+++ b/bmm/src/test/java/org/openehr/bmm/persistence/deserializer/BmmSchemaDeserializerTest.java
@@ -65,7 +65,7 @@ public class BmmSchemaDeserializerTest {
         assertEquals(7, bmmPackage.getClasses().size());
         bmmPackage = packages.get("DATA_VALUE_TYPES");
         assertEquals("Data_Value_Types", bmmPackage.getName());
-        assertEquals(24, bmmPackage.getClasses().size());
+        assertEquals(26, bmmPackage.getClasses().size());
         bmmPackage = packages.get("PARTY");
         assertEquals("Party", bmmPackage.getName());
         assertEquals(4, bmmPackage.getClasses().size());
@@ -125,7 +125,7 @@ public class BmmSchemaDeserializerTest {
         PersistedBmmGenericParameter genericParameter = intervalValue.getGenericParameterDefinitions().get("T");
         assertNotNull(genericParameter);
         assertEquals("T", genericParameter.getName());
-        assertEquals("Ordered", genericParameter.getConformsToType());
+        assertEquals("ORDERED_VALUE", genericParameter.getConformsToType());
 
         PersistedBmmSinglePropertyOpen lower = (PersistedBmmSinglePropertyOpen)intervalValue.getPropertyByName("lower");
         assertEquals("lower", lower.getName());

--- a/modeldoc/src/test/java/org/openehr/docgen/DocumentGeneratorTest.java
+++ b/modeldoc/src/test/java/org/openehr/docgen/DocumentGeneratorTest.java
@@ -2,7 +2,7 @@ package org.openehr.docgen;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.openehr.bmm.rm_access.ReferenceModelAccess;
+import org.openehr.bmm.rmaccess.ReferenceModelAccess;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -40,8 +40,7 @@ public class DocumentGeneratorTest {
             path = path.substring(0, path.lastIndexOf('/'));
             schemaDirectories.add(path);
             access = new ReferenceModelAccess();
-            access.setSchemaDirectories(schemaDirectories);
-            access.initializeAll();
+            access.initializeAll(schemaDirectories);
         } catch(Exception e) {
             e.printStackTrace();
             fail("Error initializing test");

--- a/utils/src/test/java/org/openehr/utils/validation/AnyValidatorTest.java
+++ b/utils/src/test/java/org/openehr/utils/validation/AnyValidatorTest.java
@@ -6,7 +6,6 @@ import org.openehr.utils.error.ErrorAccumulator;
 
 import java.util.ArrayList;
 
-import static com.sun.tools.internal.xjc.reader.Ring.add;
 import static org.junit.Assert.*;
 
 public class AnyValidatorTest {


### PR DESCRIPTION
the java-model-stack master branch does not compile.

This PR removes or fixes incorrect import statements and an incorrect constructor call. It also fixes two tests.

A test failure remains in the modeldoc directory.